### PR TITLE
TD-6880 Parse table fields for excel upload and download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [6.14.0] 1024-10-25
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- [TD-6880] Use a CSV-like format to define table fields in Excel, including parsing for both upload and download processes.
+
 ## [6.13.4] 2024-10-14
 
 ### Added

--- a/lib/td_df_lib/format.ex
+++ b/lib/td_df_lib/format.ex
@@ -10,6 +10,8 @@ defmodule TdDfLib.Format do
   alias TdDfLib.RichText
   alias TdDfLib.Templates
 
+  NimbleCSV.define(TableParser, separator: "\;", escape: "\"")
+
   def apply_template(content, fields, opts \\ [])
 
   def apply_template(nil, _, _opts), do: %{}
@@ -437,6 +439,25 @@ defmodule TdDfLib.Format do
       _ ->
         nil
     end
+  end
+
+  def format_field(%{"type" => "table", "content" => content}) when is_binary(content) do
+    content
+    |> TableParser.parse_string(skip_headers: false)
+    |> then(fn
+      [] ->
+        nil
+
+      [_headers] ->
+        nil
+
+      [headers | rows] ->
+        Enum.map(rows, fn row ->
+          headers
+          |> Enum.zip(row)
+          |> Map.new()
+        end)
+    end)
   end
 
   def format_field(%{"content" => content}), do: content

--- a/lib/td_df_lib/format.ex
+++ b/lib/td_df_lib/format.ex
@@ -10,8 +10,6 @@ defmodule TdDfLib.Format do
   alias TdDfLib.RichText
   alias TdDfLib.Templates
 
-  NimbleCSV.define(TableParser, separator: "\;", escape: "\"")
-
   def apply_template(content, fields, opts \\ [])
 
   def apply_template(nil, _, _opts), do: %{}
@@ -443,7 +441,7 @@ defmodule TdDfLib.Format do
 
   def format_field(%{"type" => "table", "content" => content}) when is_binary(content) do
     content
-    |> TableParser.parse_string(skip_headers: false)
+    |> Parser.Table.parse_string(skip_headers: false)
     |> then(fn
       [] ->
         nil

--- a/lib/td_df_lib/parser.ex
+++ b/lib/td_df_lib/parser.ex
@@ -136,6 +136,7 @@ defmodule TdDfLib.Parser do
     rows =
       content
       |> get_field_value(name)
+      |> value_to_list()
       |> Enum.map(fn row -> Enum.map(colums, &Map.get(row, &1, "")) end)
 
     [colums | rows]

--- a/lib/td_df_lib/parser.ex
+++ b/lib/td_df_lib/parser.ex
@@ -142,6 +142,7 @@ defmodule TdDfLib.Parser do
     [colums | rows]
     |> Parser.Table.dump_to_iodata()
     |> IO.iodata_to_binary()
+    |> String.replace_trailing("\n", "")
   end
 
   defp field_to_string(%{"name" => name} = field, content, domain_map) do

--- a/lib/td_df_lib/parser.ex
+++ b/lib/td_df_lib/parser.ex
@@ -37,7 +37,7 @@ defmodule TdDfLib.Parser do
 
     content_schema
     |> Enum.filter(fn %{"type" => schema_type, "cardinality" => cardinality} = schema ->
-      schema_type in ["url", "enriched_text", "integer", "float", "domain", "hierarchy"] or
+      schema_type in ["url", "enriched_text", "integer", "float", "domain", "hierarchy", "table"] or
         (schema_type in ["string", "user", "user_group"] and cardinality in ["*", "+"]) or
         match?(%{"fixed" => _}, Map.get(schema, "values")) or
         match?(%{"switch" => _}, Map.get(schema, "values"))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TdDfLib.MixProject do
   def project do
     [
       app: :td_df_lib,
-      version: "6.13.4",
+      version: "6.14.0",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule TdDfLib.MixProject do
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:ecto, "~> 3.10"},
       {:ex_machina, "~> 2.3", only: :test},
+      {:nimble_csv, "~> 1.1"},
       {:td_cache, git: "https://github.com/Bluetab/td-cache.git", tag: "6.13.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,7 @@
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "graph": {:git, "https://github.com/Bluetab/graph.git", "2e177db2ae80b11b134703629568a956eb300714", [tag: "1.3.0"]},
   "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
+  "nimble_csv": {:hex, :nimble_csv, "1.2.0", "4e26385d260c61eba9d4412c71cea34421f296d5353f914afe3f2e71cce97722", [:mix], [], "hexpm", "d0628117fcc2148178b034044c55359b26966c6eaa8e2ce15777be3bbc91b12a"},
   "redix": {:hex, :redix, "1.2.0", "0d7eb3ccb7b82c461a6ea28b65c2c04486093d816dd6d901a09164800e004df1", [:mix], [{:castore, "~> 0.1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "e1e0deb14599da07c77e66956a12863e85ee270ada826804a0ba8e61657e22a3"},
   "td_cache": {:git, "https://github.com/Bluetab/td-cache.git", "473941bb2d49838f14919bb4d81ca897fd454b89", [tag: "6.13.0"]},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},

--- a/test/td_df_lib/parser_test.exs
+++ b/test/td_df_lib/parser_test.exs
@@ -647,5 +647,35 @@ defmodule TdDfLib.ParserTest do
 
       assert Parser.append_parsed_fields([], fields, content) == ["value"]
     end
+
+    test "parses table fields to binary for excel download" do
+      content = %{
+        "table_name" => %{
+          "origin" => "file",
+          "value" => [
+            %{"col1" => "First Field"},
+            %{"col2" => "Second Field", "col3" => "Third Field"}
+          ]
+        }
+      }
+
+      fields = [
+        %{
+          "type" => "table",
+          "name" => "table_name",
+          "values" => %{
+            "table_columns" => [
+              %{"name" => "col1", "mandatory" => true},
+              %{"name" => "col2", "mandatory" => true},
+              %{"name" => "col3", "mandatory" => true}
+            ]
+          }
+        }
+      ]
+
+      assert Parser.append_parsed_fields([], fields, content) == [
+               "col1;col2;col3\nFirst Field;;\n;Second Field;Third Field\n"
+             ]
+    end
   end
 end

--- a/test/td_df_lib/parser_test.exs
+++ b/test/td_df_lib/parser_test.exs
@@ -673,8 +673,41 @@ defmodule TdDfLib.ParserTest do
         }
       ]
 
+      assert Parser.append_parsed_fields([], fields, content, xlsx: true) == [
+               [
+                 "col1;col2;col3\nFirst Field;;\n;Second Field;Third Field",
+                 {:align_vertical, :top}
+               ]
+             ]
+    end
+
+    test "parses table fields to binary for non excel download" do
+      content = %{
+        "table_name" => %{
+          "origin" => "file",
+          "value" => [
+            %{"col1" => "First Field"},
+            %{"col2" => "Second Field", "col3" => "Third Field"}
+          ]
+        }
+      }
+
+      fields = [
+        %{
+          "type" => "table",
+          "name" => "table_name",
+          "values" => %{
+            "table_columns" => [
+              %{"name" => "col1", "mandatory" => true},
+              %{"name" => "col2", "mandatory" => true},
+              %{"name" => "col3", "mandatory" => true}
+            ]
+          }
+        }
+      ]
+
       assert Parser.append_parsed_fields([], fields, content) == [
-               "col1;col2;col3\nFirst Field;;\n;Second Field;Third Field\n"
+               "col1;col2;col3\nFirst Field;;\n;Second Field;Third Field"
              ]
     end
   end


### PR DESCRIPTION
https://jira.bluetab.net/browse/TD-6880

Table fields to be informed as CSV-like format values, using `; ` as separator.